### PR TITLE
Fixed the bug in index.ts

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -137,24 +137,29 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     }
 
     function setCurrentlySelected() {
-      if (!fp.rContainer) return;
-      if (!fp.selectedDates.length) return;
-
-      const currentlySelected = fp.rContainer.querySelectorAll(
-        ".flatpickr-monthSelect-month.selected"
-      );
-
-      for (let index = 0; index < currentlySelected.length; index++) {
-        currentlySelected[index].classList.remove("selected");
+      if (!fp.rContainer)
+          return;
+      if (!fp.selectedDates.length)
+          return;
+      var currentlySelected = fp.rContainer.querySelectorAll(".flatpickr-monthSelect-month.selected");
+      for (var index = 0; index < currentlySelected.length; index++) {
+          currentlySelected[index].classList.remove("selected");
       }
-
-      const targetMonth = fp.selectedDates[0].getMonth();
-      const month = fp.rContainer.querySelector(
-        `.flatpickr-monthSelect-month:nth-child(${targetMonth + 1})`
-      );
+      var targetMonth = fp.selectedDates[0].getMonth();
+      var month = fp.rContainer.querySelector(".flatpickr-monthSelect-month:nth-child(" + (targetMonth + 1) + ")");
+      var months = fp.rContainer.querySelectorAll(".flatpickr-monthSelect-month");
+      var startRange = fp.rContainer.querySelector('.startRange')
+      var endRange = fp.rContainer.querySelector('.endRange')
 
       if (month) {
-        month.classList.add("selected");
+          month.classList.add("selected");
+          if (startRange && endRange && !startRange.classList.contains("selected")) {
+            for(var index=0; index < months.length - 1; index++){
+                months[index].classList.remove("startRange");
+                months[index].classList.remove("inRange");
+                months[index].classList.remove("endRange");
+                }
+          }
       }
     }
 


### PR DESCRIPTION
When a user choose two months, and then decided to create a new range without applying the chosen ones, plugin was displaying three months as selected unless the user hover to another (forth) month. I aim to unselect first two selections whenever user clicked third times.